### PR TITLE
Change how metadata is sent, fix axes/constant adding

### DIFF
--- a/bluesky_cmds/somatic/plan_ui.py
+++ b/bluesky_cmds/somatic/plan_ui.py
@@ -291,10 +291,10 @@ class ConstantWidget:
         self.frame.layout().addWidget(add_button)
         self.frame.layout().addWidget(remove_button)
 
-    def add_constant(self, hardware="d0", units="ps", terms=None):
+    def add_constant(self, hardware=None, units="ps", terms=None):
         # TODO better default
         if not hardware:
-            hardware = "d0"
+            hardware = devices_movable[0]
         if terms is None:
             terms = [[1, "d1"]]
         const = Constant(hardware, units, terms)

--- a/bluesky_cmds/somatic/plan_ui.py
+++ b/bluesky_cmds/somatic/plan_ui.py
@@ -291,8 +291,10 @@ class ConstantWidget:
         self.frame.layout().addWidget(add_button)
         self.frame.layout().addWidget(remove_button)
 
-    def add_constant(self, hardware="d0", units="mm", terms=None):
+    def add_constant(self, hardware="d0", units="ps", terms=None):
         # TODO better default
+        if not hardware:
+            hardware = "d0"
         if terms is None:
             terms = [[1, "d1"]]
         const = Constant(hardware, units, terms)
@@ -440,8 +442,9 @@ class GridscanArgsWidget(GenericScanArgsWidget):
     def __init__(self):
         super().__init__(5)
 
-    def add_axis(self, hardware="d0", start=0, stop=1, npts=11, units="mm"):
-        # TODO better default
+    def add_axis(self, hardware=None, start=0, stop=1, npts=11, units="ps"):
+        if not hardware:
+            hardware = devices_movable[0]
         axis = GridscanAxis(hardware, start, stop, npts, units)
         self.axes.append(axis)
         self.axis_container_widget.layout().addWidget(axis)
@@ -476,8 +479,9 @@ class ScanArgsWidget(GenericScanArgsWidget):
     def __init__(self):
         super().__init__(4)
 
-    def add_axis(self, hardware="d0", start=0, stop=1, units="mm"):
-        # TODO better default
+    def add_axis(self, hardware=None, start=0, stop=1, units="ps"):
+        if not hardware:
+            hardware = devices_movable[0]
         axis = ScanAxis(hardware, start, stop, units)
         self.axes.append(axis)
         self.axis_container_widget.layout().addWidget(axis)
@@ -510,8 +514,9 @@ class ListscanArgsWidget(GenericScanArgsWidget):
     def __init__(self):
         super().__init__(3)
 
-    def add_axis(self, hardware="d0", list=[], units="mm"):
-        # TODO better default
+    def add_axis(self, hardware=None, list=[], units="ps"):
+        if not hardware:
+            hardware = devices_movable[0]
         axis = ListAxis(hardware, list, units)
         self.axes.append(axis)
         self.axis_container_widget.layout().addWidget(axis)

--- a/bluesky_cmds/somatic/queue.py
+++ b/bluesky_cmds/somatic/queue.py
@@ -193,6 +193,8 @@ class GUI(QtCore.QObject):
     def on_append_to_queue(self):
         plan_name = self.plan_combo.read()
         widget = self.plan_widgets[plan_name]
+        kwargs = widget.kwargs
+        meta = kwargs.pop("md", {})
         zmq_single_request(
             "queue_item_add",
             {
@@ -200,7 +202,8 @@ class GUI(QtCore.QObject):
                     "item_type": "plan",
                     "name": plan_name,
                     "args": widget.args,
-                    "kwargs": widget.kwargs,
+                    "kwargs": kwargs,
+                    "meta": meta,
                 },
                 "user_group": "admin",
                 "user": "bluesky-cmds",


### PR DESCRIPTION
Metadata was having problems with empty string being interpretted as a device and erroring out... this just shifts to adding md one level up, which gets passed as additional kwargs to the RE.

Takes a small step towards better defaults, though a proper rework which takes into account units and such is overdue and ready to be done.