### PR TITLE
Add all group memebers to experimentor drop down

### DIFF
--- a/bluesky_cmds/somatic/plan_ui.py
+++ b/bluesky_cmds/somatic/plan_ui.py
@@ -107,7 +107,7 @@ class MetadataWidget:
         self.fields = {
             "Name": pc.String(),
             "Info": pc.String(),
-            "Experimentor": pc.Combo(["Kyle", "Emily", "Kelson", "Dan"]),
+            "Experimentor": pc.Combo(["unspecified"] + list(sorted(["Kyle", "Emily", "Kelson", "Dan", "Kent", "Peter", "Ryan", "Jason", "David", "John", "Chris", "James"]))),
         }
 
     @property


### PR DESCRIPTION
Tides us over until #19 is properly implemented

Just adds a lot of names to the combo and sorts them.

Additionally an "unspecified" option is available, and is the default
