### PR TITLE
pin bluesky dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,10 @@ classifiers = ["License :: OSI Approved :: MIT License"]
 requires-python = ">=3.7"
 requires = [
 	"appdirs",
-	"bluesky-queueserver-api",
+	"bluesky-queueserver-api=0.0.10",
+ 	"bluesky-queueserver=0.0.19",
+  	"bluesky-widgets=0.0.15",
+   	"bluesky-hwproxy=2022.8.0",
 	"click",
 	"pyqtgraph",
 	"pyside2",


### PR DESCRIPTION
- addresses #61 

versions are taken from ps table, which is running well