### PR TITLE
User-based Callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- user callbacks based off the plot updates.  It uses a similar architecture as the Bluesky Callbacks but allows
+  for an init callback as well as the typical Bluesky callbacks. User can make adjustments to an instrument
+  until proceeding to the next data point, for example.
+
 ### Changed
 - The selectable users in the plan form are no longer hard-coded; contol users in the config file.
 

--- a/bluesky_cmds/_plot.py
+++ b/bluesky_cmds/_plot.py
@@ -21,6 +21,8 @@ from bluesky_cmds._main_window import window
 
 from .logging import getLogger
 
+from .user_callbacks import UserCallbacks
+
 logger = getLogger("plot")
 
 
@@ -228,6 +230,7 @@ class PlotCallback(CallbackBase):
             self.dimensions = ["time"]
             self.all_dimensions = ["time"]
         gui.axis.set_allowed_values(self.dimensions)
+        UserCallbacks.start(self,doc)
 
         if self.start_doc.get("shape"):
             self.shape = self.start_doc["shape"]
@@ -268,6 +271,7 @@ class PlotCallback(CallbackBase):
                 if field not in self.all_dimensions:
                     self.channels.append(field)
         gui.channel.set_allowed_values(self.channels)
+        UserCallbacks.descriptor(self,doc)
 
     def event(self, doc):
         if doc["descriptor"] != self.descriptor_doc["uid"]:
@@ -282,13 +286,14 @@ class PlotCallback(CallbackBase):
         gui.idx_string.write(str(index))
 
         somatic.signals.update_plot.emit()
+        UserCallbacks.event(self,doc)
 
     def stop(self, doc):
         super().stop(doc)
         logger.info(doc)
         if doc["exit_status"] != "success":
             self.progress_bar.set_color("stop")
-
+        UserCallbacks.stop(self,doc)
 
 # TODO config rather than hardcode address
 dispatcher = RemoteDispatcher(config.get("bluesky", {}).get("zmq-proxy", "localhost:5568"))

--- a/bluesky_cmds/_plot.py
+++ b/bluesky_cmds/_plot.py
@@ -209,7 +209,7 @@ class PlotCallback(CallbackBase):
         self.units_map = {}
         self.slice_size = 2**64
         self.progress_bar = g.progress_bar
-        UserCallbacks.start(self)
+        UserCallbacks.init(self)
 
     def start(self, doc):
         logger.info(doc)

--- a/bluesky_cmds/_plot.py
+++ b/bluesky_cmds/_plot.py
@@ -209,6 +209,7 @@ class PlotCallback(CallbackBase):
         self.units_map = {}
         self.slice_size = 2**64
         self.progress_bar = g.progress_bar
+        UserCallbacks.start(self)
 
     def start(self, doc):
         logger.info(doc)

--- a/bluesky_cmds/_plot.py
+++ b/bluesky_cmds/_plot.py
@@ -231,7 +231,7 @@ class PlotCallback(CallbackBase):
             self.dimensions = ["time"]
             self.all_dimensions = ["time"]
         gui.axis.set_allowed_values(self.dimensions)
-        UserCallbacks.start(self,doc)
+        UserCallbacks.start(self, doc)
 
         if self.start_doc.get("shape"):
             self.shape = self.start_doc["shape"]
@@ -272,7 +272,7 @@ class PlotCallback(CallbackBase):
                 if field not in self.all_dimensions:
                     self.channels.append(field)
         gui.channel.set_allowed_values(self.channels)
-        UserCallbacks.descriptor(self,doc)
+        UserCallbacks.descriptor(self, doc)
 
     def event(self, doc):
         if doc["descriptor"] != self.descriptor_doc["uid"]:
@@ -287,14 +287,15 @@ class PlotCallback(CallbackBase):
         gui.idx_string.write(str(index))
 
         somatic.signals.update_plot.emit()
-        UserCallbacks.event(self,doc)
+        UserCallbacks.event(self, doc)
 
     def stop(self, doc):
         super().stop(doc)
         logger.info(doc)
         if doc["exit_status"] != "success":
             self.progress_bar.set_color("stop")
-        UserCallbacks.stop(self,doc)
+        UserCallbacks.stop(self, doc)
+
 
 # TODO config rather than hardcode address
 dispatcher = RemoteDispatcher(config.get("bluesky", {}).get("zmq-proxy", "localhost:5568"))

--- a/bluesky_cmds/user_callbacks.py
+++ b/bluesky_cmds/user_callbacks.py
@@ -2,14 +2,16 @@
 # following class is incorporated into the PlotCallback class which is used
 # in the zmq_dispatcher.  Thus it uses the plot portion of bluesky_cmds  to insert extra
 # init, start, stop, event, and descriptor processes, avoiding any further zmq dispatcher subscriptions.
-# This was deemed suitable as it was considered that additional processing for
+# This was deemed suitable because additional processing for
 # data acqusitions would likely occur from the console operating the laser system
 # and not from some remote access.  The class can also operate on the wt5 data file instead
-# of the docs, although one might have to wait until the data file is definitely
+# of the (Bluesky) docs, although one might have to wait until the data file is definitely
 # updated, which might take time, and require some method to know that it in fact
 # has updated.
 
-# import modules here as needed.  Examples include : time, WrightTools, yaqc
+
+# Recommendations and Points:
+
 # one should incorporate a logger on init to test and report on the methods' success at launch of
 # bluesky_cmds, as well as point out they are active
 
@@ -18,21 +20,56 @@
 # the plot script to move the calls to these methods at some time where users can conclude
 # they are most satisfactory **within** the plot processing.
 
-import yaqc
-import time
+# You may also want to have try, except routines and report on those if they fail, will help
+# validate callbacks are working as they should, and perhaps allow the other portion of 
+# bluesky-cmds to proceed even if they do fail.
 
-c=yaqc.Client(38996)
+# Create methods for validating an updated wt5, validating any Clients specially used here are working,
+# etc. here.  Call these in the Callbacks below as needed.
+
+# recommend parsing text generated during callbacks into a text file that should get appended to 
+# a wt data file at the stop callback.  It might be good to read this script as text and put it into
+# the parsed text, in order to keep a record of it.  It can also be written to a separate text file
+# in the data folder.
+
+
+# import modules here as needed.  Examples include : time, WrightTools, yaqc, bluesky_queueserver_api
+
+import sys
+#import os
+#import pathlib
+#import WrightTools as wt
+#import time
+
+if sys.platform:
+    import asyncio
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
 
 class UserCallbacks():
     def init(self):
         # User-defined process for initialization at time of zmq-dispatcher subscription 
-        # of _plot.   Cannot use docs.
-        print("initialization done")
+        # of _plot.   This occurs at launch of bluesky-cmds.  Cannot use docs.
+        #print("User callback initialization complete")        
         pass
 
     def start(self, doc):
-        # User-defined process for the start of the acquisition here
-        print("start done")
+        # User-defined process for the start of the acquisition here.  
+        
+        # sample code for finding the wt5 data folder for the current run (see wt5 in bluesky-in-a-box)
+        '''
+        time.sleep(0.5)
+        timestamp = wt.kit.TimeStamp(self.start_doc["time"])
+        path_parts = []
+        path_parts.append(timestamp.path)
+        path_parts.append(self.start_doc.get("plan_name"))
+        path_parts.append(self.start_doc.get("Name"))
+        path_parts.append(self.start_doc.get("uid")[:8])
+        dirname = " ".join(x for x in path_parts if x)
+        self.run_dir = pathlib.Path("C:/Users/john/bluesky-cmds-data") / dirname
+        # would be good to examine wt5 file size as reference to see if it is being updated
+        '''
+        #print("User start callback done")
         pass
 
     def descriptor(self, doc):
@@ -41,18 +78,10 @@ class UserCallbacks():
 
     def event(self, doc):
         # User-defined process for Bluesky events here (This is most likely where code is entered)
-        id=c.get_measured()['measurement_id']
-        idn=id
-        while idn==id:
-            data=c.get_measured()
-            idn=data['measurement_id']
-            
-            time.sleep(0.1)
-        meas=data['random_walk']
-        print(meas)
+        #print("User event callback done")
         pass
 
     def stop(self, doc):
         # User-defined process at stop of a run here
-        print("stop done")
+        #print("User stop callback done")
         pass

--- a/bluesky_cmds/user_callbacks.py
+++ b/bluesky_cmds/user_callbacks.py
@@ -9,6 +9,8 @@
 # updated, which might take time
 
 # import modules here as needed.  Examples include : time, WrightTools, yaqc
+# one should incorporate a logger to test and report on the methods' success at launch of
+# bluesky_cmds, as well as point out they are active
 
 class UserCallbacks():
     def start(self, doc):

--- a/bluesky_cmds/user_callbacks.py
+++ b/bluesky_cmds/user_callbacks.py
@@ -1,4 +1,4 @@
-# user callbacks file  
+# user callbacks file
 # following class is incorporated into the PlotCallback class which is used
 # in the zmq_dispatcher.  Thus it uses the plot portion of bluesky_cmds  to insert extra
 # init, start, stop, event, and descriptor processes, avoiding any further zmq dispatcher subscriptions.
@@ -21,13 +21,13 @@
 # they are most satisfactory **within** the plot processing.
 
 # You may also want to have try, except routines and report on those if they fail, will help
-# validate callbacks are working as they should, and perhaps allow the other portion of 
+# validate callbacks are working as they should, and perhaps allow the other portion of
 # bluesky-cmds to proceed even if they do fail.
 
 # Create methods for validating an updated wt5, validating any Clients specially used here are working,
 # etc. here.  Call these in the Callbacks below as needed.
 
-# recommend parsing text generated during callbacks into a text file that should get appended to 
+# recommend parsing text generated during callbacks into a text file that should get appended to
 # a wt data file at the stop callback.  It might be good to read this script as text and put it into
 # the parsed text, in order to keep a record of it.  It can also be written to a separate text file
 # in the data folder.
@@ -36,28 +36,30 @@
 # import modules here as needed.  Examples include : time, WrightTools, yaqc, bluesky_queueserver_api
 
 import sys
-#import os
-#import pathlib
-#import WrightTools as wt
-#import time
+
+# import os
+# import pathlib
+# import WrightTools as wt
+# import time
 
 if sys.platform:
     import asyncio
+
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 
-class UserCallbacks():
+class UserCallbacks:
     def init(self):
-        # User-defined process for initialization at time of zmq-dispatcher subscription 
+        # User-defined process for initialization at time of zmq-dispatcher subscription
         # of _plot.   This occurs at launch of bluesky-cmds.  Cannot use docs.
-        #print("User callback initialization complete")        
+        # print("User callback initialization complete")
         pass
 
     def start(self, doc):
-        # User-defined process for the start of the acquisition here.  
-        
+        # User-defined process for the start of the acquisition here.
+
         # sample code for finding the wt5 data folder for the current run (see wt5 in bluesky-in-a-box)
-        '''
+        """
         time.sleep(0.5)
         timestamp = wt.kit.TimeStamp(self.start_doc["time"])
         path_parts = []
@@ -68,8 +70,8 @@ class UserCallbacks():
         dirname = " ".join(x for x in path_parts if x)
         self.run_dir = pathlib.Path("C:/Users/john/bluesky-cmds-data") / dirname
         # would be good to examine wt5 file size as reference to see if it is being updated
-        '''
-        #print("User start callback done")
+        """
+        # print("User start callback done")
         pass
 
     def descriptor(self, doc):
@@ -78,10 +80,10 @@ class UserCallbacks():
 
     def event(self, doc):
         # User-defined process for Bluesky events here (This is most likely where code is entered)
-        #print("User event callback done")
+        # print("User event callback done")
         pass
 
     def stop(self, doc):
         # User-defined process at stop of a run here
-        #print("User stop callback done")
+        # print("User stop callback done")
         pass

--- a/bluesky_cmds/user_callbacks.py
+++ b/bluesky_cmds/user_callbacks.py
@@ -1,30 +1,58 @@
 # user callbacks file  
 # following class is incorporated into the PlotCallback class which is used
 # in the zmq_dispatcher.  Thus it uses the plot portion of bluesky_cmds  to insert extra
-# start, stop, event, and descriptor processes, avoiding any further dispatchers.
+# init, start, stop, event, and descriptor processes, avoiding any further zmq dispatcher subscriptions.
 # This was deemed suitable as it was considered that additional processing for
 # data acqusitions would likely occur from the console operating the laser system
-# and not from some remote access.  It can also operate on the wt5 data file instead
+# and not from some remote access.  The class can also operate on the wt5 data file instead
 # of the docs, although one might have to wait until the data file is definitely
-# updated, which might take time
+# updated, which might take time, and require some method to know that it in fact
+# has updated.
 
 # import modules here as needed.  Examples include : time, WrightTools, yaqc
-# one should incorporate a logger to test and report on the methods' success at launch of
+# one should incorporate a logger on init to test and report on the methods' success at launch of
 # bluesky_cmds, as well as point out they are active
 
+# These methods are followed at the **end** of the Plot callback process.  It may be
+# important to have a separate set of methods **before** any plotting occurs, or to modify
+# the plot script to move the calls to these methods at some time where users can conclude
+# they are most satisfactory **within** the plot processing.
+
+import yaqc
+import time
+
+c=yaqc.Client(38996)
+
 class UserCallbacks():
+    def init(self):
+        # User-defined process for initialization at time of zmq-dispatcher subscription 
+        # of _plot.   Cannot use docs.
+        print("initialization done")
+        pass
+
     def start(self, doc):
         # User-defined process for the start of the acquisition here
+        print("start done")
         pass
 
     def descriptor(self, doc):
-        # User-defined process for descriptors here
+        # User-defined process for Bluesky descriptors here
         pass
 
     def event(self, doc):
-        # User-defined process for events here (This is most likely where code is entered)
+        # User-defined process for Bluesky events here (This is most likely where code is entered)
+        id=c.get_measured()['measurement_id']
+        idn=id
+        while idn==id:
+            data=c.get_measured()
+            idn=data['measurement_id']
+            
+            time.sleep(0.1)
+        meas=data['random_walk']
+        print(meas)
         pass
 
     def stop(self, doc):
-        # User-defined process for stopping a run here
+        # User-defined process at stop of a run here
+        print("stop done")
         pass

--- a/bluesky_cmds/user_callbacks.py
+++ b/bluesky_cmds/user_callbacks.py
@@ -1,0 +1,28 @@
+# user callbacks file  
+# following class is incorporated into the PlotCallback class which is used
+# in the zmq_dispatcher.  Thus it uses the plot portion of bluesky_cmds  to insert extra
+# start, stop, event, and descriptor processes, avoiding any further dispatchers.
+# This was deemed suitable as it was considered that additional processing for
+# data acqusitions would likely occur from the console operating the laser system
+# and not from some remote access.  It can also operate on the wt5 data file instead
+# of the docs, although one might have to wait until the data file is definitely
+# updated, which might take time
+
+# import modules here as needed.  Examples include : time, WrightTools, yaqc
+
+class UserCallbacks():
+    def start(self, doc):
+        # User-defined process for the start of the acquisition here
+        pass
+
+    def descriptor(self, doc):
+        # User-defined process for descriptors here
+        pass
+
+    def event(self, doc):
+        # User-defined process for events here (This is most likely where code is entered)
+        pass
+
+    def stop(self, doc):
+        # User-defined process for stopping a run here
+        pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,10 @@ classifiers = ["License :: OSI Approved :: MIT License"]
 requires-python = ">=3.7"
 requires = [
 	"appdirs",
-	"bluesky-queueserver-api=0.0.10",
- 	"bluesky-queueserver=0.0.19",
-  	"bluesky-widgets=0.0.15",
-   	"bluesky-hwproxy=2022.8.0",
+	"bluesky-queueserver-api==0.0.10",
+ 	"bluesky-queueserver==0.0.19",
+ 	"bluesky-widgets==0.0.15",
+ 	"bluesky-hwproxy==2022.8.0",
 	"click",
 	"pyqtgraph",
 	"pyside2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,10 @@ classifiers = ["License :: OSI Approved :: MIT License"]
 requires-python = ">=3.7"
 requires = [
 	"appdirs",
-	"bluesky-queueserver-api==0.0.10",
- 	"bluesky-queueserver==0.0.19",
- 	"bluesky-widgets==0.0.15",
- 	"bluesky-hwproxy==2022.8.0",
+	"bluesky-queueserver-api=0.0.10",
+ 	"bluesky-queueserver=0.0.19",
+ 	"bluesky-widgets=0.0.15",
+ 	"bluesky-hwproxy=2022.8.0",
 	"click",
 	"pyqtgraph",
 	"pyside2",


### PR DESCRIPTION
Wrote a fix to allow user processing during a scan independent of plan, using the plot routine.  This keeps the Dispatcher limited to one callback on the instrument directly,  Docker containers not-withstanding.

Because we recommend flit install -s, it makes sense to edit the callbacks as needed.  However, keeping track of them may require an additional text file generated in the scan's data folder. 

Sample code for finding the data folder included, uses wt3_event_model but now is resting on the plot callback instead of the wt5 callback.  

Works for yaqd-fakes.    Asyncio event policy warning forced inclusion of a policy in code.   Somehow it at first didn't warn about the policy, then it started warning about the policy, then removing code that should have stopped making it warn about it did not stop the warning.

Closes #50  potentially